### PR TITLE
feat(QYOG-22): 추가된 api 사항 적용 및 class 형 api 선언 방식 주석 처리

### DIFF
--- a/src/@types/apis/Apis.d.ts
+++ b/src/@types/apis/Apis.d.ts
@@ -124,6 +124,232 @@ declare global {
       profilePath: string | null;
     }
 
+    export interface FreeBoardDto {
+      /**
+       * 고유 ID
+       * @min 1
+       */
+      id: number;
+      /**
+       * 생성일자
+       * @format date-time
+       */
+      createdAt: string;
+      /**
+       * 수정일자
+       * @format date-time
+       */
+      updatedAt: string;
+      /**
+       * 게시글 작성자 고유 ID
+       * @format integer
+       */
+      userId: number;
+      /**
+       * 제목
+       * @minLength 1
+       * @maxLength 255
+       */
+      title: string;
+      /** 본문 */
+      description: string;
+      /**
+       * 조회수
+       * @format integer
+       * @default 0
+       */
+      hit: number;
+      /** 익명 여부 */
+      isAnonymous: boolean;
+    }
+
+    export interface CreateFreeBoardDto {
+      /**
+       * 제목
+       * @minLength 1
+       * @maxLength 255
+       */
+      title: string;
+      /** 본문 */
+      description: string;
+      /**
+       * 익명 여부
+       * @default false
+       */
+      isAnonymous: boolean;
+    }
+
+    export interface FreeBoardDetailResponseDto {
+      freeBoard: FreeBoardDto;
+    }
+
+    export interface FreeBoardsItemDto {
+      /**
+       * 고유 ID
+       * @min 1
+       */
+      id: number;
+      /**
+       * 생성일자
+       * @format date-time
+       */
+      createdAt: string;
+      /**
+       * 수정일자
+       * @format date-time
+       */
+      updatedAt: string;
+      /**
+       * 게시글 작성자 고유 ID
+       * @format integer
+       */
+      userId: number;
+      /**
+       * 제목
+       * @minLength 1
+       * @maxLength 255
+       */
+      title: string;
+      /**
+       * 조회수
+       * @format integer
+       * @default 0
+       */
+      hit: number;
+      /** 익명 여부 */
+      isAnonymous: boolean;
+    }
+
+    export interface FreeBoardsPaginationResponseDto {
+      /**
+       * 총 페이지 수
+       * @format integer
+       * @min 1
+       */
+      totalCount: number;
+      /**
+       * 한 요청에 대한 data 수
+       * @format integer
+       * @min 1
+       */
+      pageSize: number;
+      /**
+       * 현재 페이지 번호
+       * @format integer
+       * @min 1
+       */
+      currentPage: number;
+      /**
+       * 다음 페이지 번호, 다음 페이지가 없다면 null 반환
+       * @format integer
+       * @min 2
+       */
+      nextPage: number | null;
+      /**
+       * 다음 페이지 존재 여부
+       * @min 1
+       */
+      hasNext: boolean;
+      /**
+       * 마지막 페이지 번호
+       * @format integer
+       * @min 1
+       */
+      lastPage: number;
+      freeBoards: FreeBoardsItemDto[];
+    }
+
+    export interface PutUpdateFreeBoardDto {
+      /**
+       * 제목
+       * @minLength 1
+       * @maxLength 255
+       */
+      title: string;
+      /** 본문 */
+      description: string;
+      /** 익명 여부 */
+      isAnonymous: boolean;
+    }
+
+    export interface PatchUpdateFreeBoardDto {
+      /**
+       * 제목
+       * @minLength 1
+       * @maxLength 255
+       */
+      title?: string;
+      /** 본문 */
+      description?: string;
+      /** 익명 여부 */
+      isAnonymous?: boolean;
+    }
+
+    export interface MajorDto {
+      /**
+       * 고유 ID
+       * @min 1
+       */
+      id: number;
+      /**
+       * 생성일자
+       * @format date-time
+       */
+      createdAt: string;
+      /**
+       * 수정일자
+       * @format date-time
+       */
+      updatedAt: string;
+      /**
+       * 전공 코드
+       * @minLength 1
+       * @maxLength 20
+       */
+      code: string;
+      /**
+       * 전공 이름
+       * @minLength 1
+       * @maxLength 50
+       */
+      name: string;
+      /**
+       * 전공 메모
+       * @minLength 0
+       * @maxLength 255
+       */
+      memo: string;
+    }
+
+    export interface MajorCommonResponseDto {
+      major: MajorDto;
+    }
+
+    export interface CreateMajorRequestBodyDto {
+      /**
+       * 전공 코드
+       * @minLength 1
+       * @maxLength 20
+       */
+      code: string;
+      /**
+       * 전공 이름
+       * @minLength 1
+       * @maxLength 50
+       */
+      name: string;
+      /**
+       * 전공 생성한 이유 메모
+       * @minLength 0
+       * @maxLength 255
+       */
+      memo: string;
+    }
+
+    export interface MajorDetailResponseDto {
+      major: MajorDto;
+    }
+
     /** login type 현재 email 만 */
     export type SignInRequestBodyDtoLoginTypeEnum = "email";
 
@@ -216,6 +442,267 @@ declare global {
     export type UsersCreateMessageEnum2 =
       "Server error. Please contact server developer";
 
+    /**
+     * error code
+     * @example 1
+     */
+    export type FreeBoardCreateCodeEnum = "1";
+
+    /** error message */
+    export type FreeBoardCreateMessageEnum =
+      "Invalid request parameter. Please check your request.";
+
+    /**
+     * error code
+     * @example 3
+     */
+    export type FreeBoardCreateCodeEnum1 = "3";
+
+    /** error message */
+    export type FreeBoardCreateMessageEnum1 = "This token is invalid.";
+
+    /**
+     * error code
+     * @example 0
+     */
+    export type FreeBoardCreateCodeEnum2 = "0";
+
+    /** error message */
+    export type FreeBoardCreateMessageEnum2 =
+      "Server error. Please contact server developer";
+
+    /**
+     * error code
+     * @example 1
+     */
+    export type FreeBoardFindAllAndCountCodeEnum = "1";
+
+    /** error message */
+    export type FreeBoardFindAllAndCountMessageEnum =
+      "Invalid request parameter. Please check your request.";
+
+    /**
+     * error code
+     * @example 0
+     */
+    export type FreeBoardFindAllAndCountCodeEnum1 = "0";
+
+    /** error message */
+    export type FreeBoardFindAllAndCountMessageEnum1 =
+      "Server error. Please contact server developer";
+
+    export interface FreeBoardFindAllAndCountParams {
+      /**
+       * 페이지번호
+       * @format integer
+       * @min 1
+       * @default 1
+       */
+      page?: number;
+      /**
+       * 페이지당 아이템 수
+       * @format integer
+       * @min 1
+       * @max 100
+       * @default 20
+       */
+      pageSize?: number;
+      /**
+       * 자유게시글 고유 ID 필터링
+       * @format integer
+       */
+      id?: number;
+      /**
+       * 자유게시글 작성자 고유 ID 필터링
+       * @format integer
+       */
+      userId?: number;
+      /**
+       * title 필터링
+       * @maxLength 255
+       */
+      title?: string;
+      /** 익명여부 필터링 */
+      isAnonymous?: IsAnonymousEnum;
+      /**
+       * 정렬 필드<br>csv 형태로 보내야합니다.<br>- 가 붙으면 내림차순 - 가 붙지 않으면 오름차순<br>허용된 filed: [id, userId, title, hit, isAnonymous, createdAt, updatedAt]
+       * @format csv
+       * @default "id"
+       * @example "-id,updatedAt"
+       */
+      order?: string;
+    }
+
+    /** 익명여부 필터링 */
+    export type IsAnonymousEnum = "true" | "false" | "0" | "1";
+
+    /** 익명여부 필터링 */
+    export type FreeBoardFindAllAndCountParams1IsAnonymousEnum =
+      | "true"
+      | "false"
+      | "0"
+      | "1";
+
+    /**
+     * error code
+     * @example 1
+     */
+    export type FreeBoardFindOneOrNotFoundCodeEnum = "1";
+
+    /** error message */
+    export type FreeBoardFindOneOrNotFoundMessageEnum =
+      "Invalid request parameter. Please check your request.";
+
+    /**
+     * error code
+     * @example 5
+     */
+    export type FreeBoardFindOneOrNotFoundCodeEnum1 = "5";
+
+    /** error message */
+    export type FreeBoardFindOneOrNotFoundMessageEnum1 =
+      "The resource you're trying to access doesn't exist.";
+
+    /**
+     * error code
+     * @example 1
+     */
+    export type FreeBoardPutUpdateCodeEnum = "1";
+
+    /** error message */
+    export type FreeBoardPutUpdateMessageEnum =
+      "Invalid request parameter. Please check your request.";
+
+    /**
+     * error code
+     * @example 3
+     */
+    export type FreeBoardPutUpdateCodeEnum1 = "3";
+
+    /** error message */
+    export type FreeBoardPutUpdateMessageEnum1 = "This token is invalid.";
+
+    /**
+     * error code
+     * @example 4
+     */
+    export type FreeBoardPutUpdateCodeEnum2 = "4";
+
+    /** error message */
+    export type FreeBoardPutUpdateMessageEnum2 =
+      "You don't have permission to access it.";
+
+    /**
+     * error code
+     * @example 5
+     */
+    export type FreeBoardPutUpdateCodeEnum3 = "5";
+
+    /** error message */
+    export type FreeBoardPutUpdateMessageEnum3 =
+      "The resource you're trying to access doesn't exist.";
+
+    /**
+     * error code
+     * @example 0
+     */
+    export type FreeBoardPutUpdateCodeEnum4 = "0";
+
+    /** error message */
+    export type FreeBoardPutUpdateMessageEnum4 =
+      "Server error. Please contact server developer";
+
+    /**
+     * error code
+     * @example 1
+     */
+    export type FreeBoardPatchUpdateCodeEnum = "1" | "6";
+
+    /** error message */
+    export type FreeBoardPatchUpdateMessageEnum =
+      | "Invalid request parameter. Please check your request."
+      | "At least one update field must exist.";
+
+    /**
+     * error code
+     * @example 3
+     */
+    export type FreeBoardPatchUpdateCodeEnum1 = "3";
+
+    /** error message */
+    export type FreeBoardPatchUpdateMessageEnum1 = "This token is invalid.";
+
+    /**
+     * error code
+     * @example 4
+     */
+    export type FreeBoardPatchUpdateCodeEnum2 = "4";
+
+    /** error message */
+    export type FreeBoardPatchUpdateMessageEnum2 =
+      "You don't have permission to access it.";
+
+    /**
+     * error code
+     * @example 5
+     */
+    export type FreeBoardPatchUpdateCodeEnum3 = "5";
+
+    /** error message */
+    export type FreeBoardPatchUpdateMessageEnum3 =
+      "The resource you're trying to access doesn't exist.";
+
+    /**
+     * error code
+     * @example 0
+     */
+    export type FreeBoardPatchUpdateCodeEnum4 = "0";
+
+    /** error message */
+    export type FreeBoardPatchUpdateMessageEnum4 =
+      "Server error. Please contact server developer";
+
+    /**
+     * error code
+     * @example 0
+     */
+    export type GetAllMajorsCodeEnum = "0";
+
+    /** error message */
+    export type GetAllMajorsMessageEnum =
+      "Server error. Please contact server developer";
+
+    /**
+     * error code
+     * @example 1
+     */
+    export type CreateNewMajorCodeEnum = "1";
+
+    /** error message */
+    export type CreateNewMajorMessageEnum =
+      "Invalid request parameter. Please check your request.";
+
+    /**
+     * error code
+     * @example 3000
+     */
+    export type CreateNewMajorCodeEnum1 = "3000" | "3001";
+
+    /** error message */
+    export type CreateNewMajorMessageEnum1 =
+      | "Major name that already exists"
+      | "Major code that already exists.";
+
+    /**
+     * error code
+     * @example 0
+     */
+    export type CreateNewMajorCodeEnum2 = "0";
+
+    /** error message */
+    export type CreateNewMajorMessageEnum2 =
+      "Server error. Please contact server developer";
+
     export namespace Api {
       /**
        * @description 서버에서 관리하는 에러코드를 조회합니다.
@@ -293,6 +780,153 @@ declare global {
         export type RequestBody = CreateUserRequestBodyDto;
         export type RequestHeaders = {};
         export type ResponseBody = UserDetailResponseDto;
+      }
+      /**
+       * No description
+       * @tags free-boards
+       * @name FreeBoardCreate
+       * @summary 자유 게시글 생성
+       * @request POST:/api/free-boards
+       * @secure
+       */
+      export namespace FreeBoardCreate {
+        export type RequestParams = {};
+        export type RequestQuery = {};
+        export type RequestBody = CreateFreeBoardDto;
+        export type RequestHeaders = {};
+        export type ResponseBody = FreeBoardDetailResponseDto;
+      }
+      /**
+       * No description
+       * @tags free-boards
+       * @name FreeBoardFindAllAndCount
+       * @summary 자유 게시글 전체조회(pagination)
+       * @request GET:/api/free-boards
+       */
+      export namespace FreeBoardFindAllAndCount {
+        export type RequestParams = {};
+        export type RequestQuery = {
+          /**
+           * 페이지번호
+           * @format integer
+           * @min 1
+           * @default 1
+           */
+          page?: number;
+          /**
+           * 페이지당 아이템 수
+           * @format integer
+           * @min 1
+           * @max 100
+           * @default 20
+           */
+          pageSize?: number;
+          /**
+           * 자유게시글 고유 ID 필터링
+           * @format integer
+           */
+          id?: number;
+          /**
+           * 자유게시글 작성자 고유 ID 필터링
+           * @format integer
+           */
+          userId?: number;
+          /**
+           * title 필터링
+           * @maxLength 255
+           */
+          title?: string;
+          /** 익명여부 필터링 */
+          isAnonymous?: FreeBoardFindAllAndCountParams1IsAnonymousEnum;
+          /**
+           * 정렬 필드<br>csv 형태로 보내야합니다.<br>- 가 붙으면 내림차순 - 가 붙지 않으면 오름차순<br>허용된 filed: [id, userId, title, hit, isAnonymous, createdAt, updatedAt]
+           * @format csv
+           * @default "id"
+           * @example "-id,updatedAt"
+           */
+          order?: string;
+        };
+        export type RequestBody = never;
+        export type RequestHeaders = {};
+        export type ResponseBody = FreeBoardsPaginationResponseDto;
+      }
+      /**
+       * No description
+       * @tags free-boards
+       * @name FreeBoardFindOneOrNotFound
+       * @summary 자유게시글 상세조회
+       * @request GET:/api/free-boards/{freeBoardId}
+       */
+      export namespace FreeBoardFindOneOrNotFound {
+        export type RequestParams = {
+          freeBoardId: number;
+        };
+        export type RequestQuery = {};
+        export type RequestBody = never;
+        export type RequestHeaders = {};
+        export type ResponseBody = FreeBoardDetailResponseDto;
+      }
+      /**
+       * No description
+       * @tags free-boards
+       * @name FreeBoardPutUpdate
+       * @summary 자유게시글 수정
+       * @request PUT:/api/free-boards/{freeBoardId}
+       * @secure
+       */
+      export namespace FreeBoardPutUpdate {
+        export type RequestParams = {
+          freeBoardId: number;
+        };
+        export type RequestQuery = {};
+        export type RequestBody = PutUpdateFreeBoardDto;
+        export type RequestHeaders = {};
+        export type ResponseBody = FreeBoardDetailResponseDto;
+      }
+      /**
+       * No description
+       * @tags free-boards
+       * @name FreeBoardPatchUpdate
+       * @summary 자유게시글 부분 수정
+       * @request PATCH:/api/free-boards/{freeBoardId}
+       * @secure
+       */
+      export namespace FreeBoardPatchUpdate {
+        export type RequestParams = {
+          freeBoardId: number;
+        };
+        export type RequestQuery = {};
+        export type RequestBody = PatchUpdateFreeBoardDto;
+        export type RequestHeaders = {};
+        export type ResponseBody = FreeBoardDetailResponseDto;
+      }
+      /**
+       * No description
+       * @tags major
+       * @name GetAllMajors
+       * @summary 전공 목록 전체 조회
+       * @request GET:/api/major
+       */
+      export namespace GetAllMajors {
+        export type RequestParams = {};
+        export type RequestQuery = {};
+        export type RequestBody = never;
+        export type RequestHeaders = {};
+        export type ResponseBody = MajorCommonResponseDto;
+      }
+      /**
+       * No description
+       * @tags major
+       * @name CreateNewMajor
+       * @summary 전공 코드 및 이름 생성
+       * @request POST:/api/major
+       */
+      export namespace CreateNewMajor {
+        export type RequestParams = {};
+        export type RequestQuery = {};
+        export type RequestBody = CreateMajorRequestBodyDto;
+        export type RequestHeaders = {};
+        export type ResponseBody = MajorDetailResponseDto;
       }
     }
   }

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -6,7 +6,7 @@
 
 import instance from "./instance";
 
-const apiPath = (path?: string) => `/auth${path && `/${path}`}`;
+const apiPath = (path?: string) => `/auth${path ? `/${path}` : ""}`;
 
 /**
  * 로그인
@@ -43,3 +43,46 @@ export const generateAccessToken = async (
     );
   return result.data;
 };
+
+// class AuthAPI extends BaseAPIInstance {
+//   constructor() {
+//     super();
+//   }
+
+//   private _apiPath = (path?: string) => `/auth${path ? `/${path}` : ""}`;
+
+//   /**
+//    * 로그인
+//    */
+//   signIn = async (args: Swagger.Api.AuthSignIn.RequestBody) => {
+//     const result = await this.instance.post<Swagger.Api.AuthSignIn.ResponseBody>(
+//       this._apiPath("sign-in"),
+//       args
+//     );
+//     return result.data;
+//   };
+
+//   /**
+//    * 로그인한 유저 정보 조회
+//    */
+//   getProfile = async () => {
+//     const result = await this.instance.get<Swagger.Api.AuthGetProfile.ResponseBody>(
+//       this._apiPath("profile")
+//     );
+//     return result.data;
+//   };
+
+//   /**
+//    * `개발용`
+//    * access token 생성
+//    */
+//   generateAccessToken = async (
+//     args: Swagger.Api.AuthGetAccessToken.RequestParams
+//   ) => {
+//     const result =
+//       await this.instance.get<Swagger.Api.AuthGetAccessToken.ResponseBody>(
+//         this._apiPath(`access-token/${args.userId}`)
+//       );
+//     return result.data;
+//   };
+// }

--- a/src/apis/boards.ts
+++ b/src/apis/boards.ts
@@ -1,0 +1,180 @@
+/*
+ * Created on Mon Dec 04 2023
+ *
+ * Copyright (c) 2023 Your Company
+ */
+
+import instance from "./instance";
+
+const freeBoardAPI = () => {
+  const apiPath = (path?: string) => {
+    return `/free-boards${path ? `/${path}` : ""}`;
+  };
+
+  /**
+   * 자유 게시글 생성
+   */
+  const createPost = async (args: Swagger.Api.FreeBoardCreate.RequestBody) => {
+    const result =
+      await instance.post<Swagger.Api.FreeBoardCreate.ResponseBody>(
+        apiPath(),
+        args
+      );
+    return result.data;
+  };
+
+  /**
+   * 자유 게시글 전체조회
+   */
+  const getAll = async (
+    args: Swagger.Api.FreeBoardFindAllAndCount.RequestQuery
+  ) => {
+    const result =
+      await instance.get<Swagger.Api.FreeBoardFindAllAndCount.ResponseBody>(
+        apiPath(),
+        { params: args }
+      );
+    return result.data;
+  };
+
+  const getPost = async (
+    args: Swagger.Api.FreeBoardFindOneOrNotFound.RequestParams
+  ) => {
+    const result =
+      await instance.get<Swagger.Api.FreeBoardFindOneOrNotFound.ResponseBody>(
+        apiPath(`${args.freeBoardId}`)
+      );
+    return result.data;
+  };
+
+  /**
+   * 자유게시글 수정
+   */
+  const updatePost = async (
+    args: Swagger.Api.FreeBoardPutUpdate.RequestBody &
+      Swagger.Api.FreeBoardPutUpdate.RequestParams
+  ) => {
+    const data = { ...args } as Partial<
+      Swagger.Api.FreeBoardPutUpdate.RequestBody &
+        Swagger.Api.FreeBoardPutUpdate.RequestParams
+    >;
+
+    delete data.freeBoardId;
+
+    const result =
+      await instance.put<Swagger.Api.FreeBoardPutUpdate.ResponseBody>(
+        apiPath(`${args.freeBoardId}`),
+        data
+      );
+    return result.data;
+  };
+
+  /**
+   * 자유게시글 부분 수정
+   */
+  const patchPost = async (
+    args: Swagger.Api.FreeBoardPatchUpdate.RequestBody &
+      Swagger.Api.FreeBoardPatchUpdate.RequestParams
+  ) => {
+    const data = { ...args } as Partial<
+      Swagger.Api.FreeBoardPatchUpdate.RequestBody &
+        Swagger.Api.FreeBoardPatchUpdate.RequestParams
+    >;
+
+    delete data.freeBoardId;
+
+    const result =
+      await instance.patch<Swagger.Api.FreeBoardPatchUpdate.ResponseBody>(
+        apiPath(`${args.freeBoardId}`),
+        data
+      );
+    return result.data;
+  };
+
+  return { createPost, getAll, getPost, updatePost, patchPost };
+};
+
+export const freeBoard = freeBoardAPI();
+
+// class FreeBoardAPI extends BaseAPIInstance {
+//   constructor() {
+//     super();
+//   }
+//   private _apiPath = (path?: string) => {
+//     return `/free-boards${path ? `/${path}` : ""}`;
+//   };
+
+//   /**
+//    * 자유 게시글 생성
+//    */
+//   createPost = async (args: Swagger.Api.FreeBoardCreate.RequestBody) => {
+//     const result = await this.instance.post(this._apiPath(), args);
+//     return result.data;
+//   };
+
+//   /**
+//    * 자유 게시글 전체조회
+//    */
+//   getAll = async (args: Swagger.Api.FreeBoardFindAllAndCount.RequestQuery) => {
+//     const result =
+//       await this.instance.get<Swagger.Api.FreeBoardFindAllAndCount.ResponseBody>(
+//         this._apiPath(),
+//         { params: args }
+//       );
+//     return result.data;
+//   };
+
+//   getPost = async (
+//     args: Swagger.Api.FreeBoardFindOneOrNotFound.RequestParams
+//   ) => {
+//     const result =
+//       await this.instance.get<Swagger.Api.FreeBoardFindOneOrNotFound.ResponseBody>(
+//         this._apiPath(`${args.freeBoardId}`)
+//       );
+//     return result.data;
+//   };
+
+//   /**
+//    * 자유게시글 수정
+//    */
+//   updatePost = async (
+//     args: Swagger.Api.FreeBoardPutUpdate.RequestBody &
+//       Swagger.Api.FreeBoardPutUpdate.RequestParams
+//   ) => {
+//     const data = { ...args } as Partial<
+//       Swagger.Api.FreeBoardPutUpdate.RequestBody &
+//         Swagger.Api.FreeBoardPutUpdate.RequestParams
+//     >;
+
+//     delete data.freeBoardId;
+
+//     const result =
+//       await this.instance.put<Swagger.Api.FreeBoardPutUpdate.ResponseBody>(
+//         this._apiPath(`${args.freeBoardId}`),
+//         data
+//       );
+//     return result.data;
+//   };
+
+//   /**
+//    * 자유게시글 부분 수정
+//    */
+//   patchPost = async (
+//     args: Swagger.Api.FreeBoardPatchUpdate.RequestBody &
+//       Swagger.Api.FreeBoardPatchUpdate.RequestParams
+//   ) => {
+//     const data = { ...args } as Partial<
+//       Swagger.Api.FreeBoardPatchUpdate.RequestBody &
+//         Swagger.Api.FreeBoardPatchUpdate.RequestParams
+//     >;
+
+//     delete data.freeBoardId;
+
+//     const result =
+//       await this.instance.patch<Swagger.Api.FreeBoardPatchUpdate.ResponseBody>(
+//         this._apiPath(`${args.freeBoardId}`),
+//         data
+//       );
+//     return result.data;
+//   };
+// }

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -7,3 +7,6 @@
 export * as ErrorCode from "./errorCode";
 
 export * as authAPI from "./auth";
+export * as boardsAPI from "./boards";
+export * as usersAPI from "./users";
+export * as majorAPI from "./major";

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -13,4 +13,37 @@ const instance = axios.create({
   },
 });
 
+instance.interceptors.request.use((value) => {
+  return value;
+});
+
+instance.interceptors.request.use((value) => {
+  return value;
+});
+
 export default instance;
+
+// export class BaseAPIInstance {
+//   private _instance: AxiosInstance;
+
+//   constructor() {
+//     this._instance = axios.create({
+//       baseURL: process.env.NEXT_PUBLIC_API_DOMAIN,
+//       headers: {
+//         "x-auth-token": "token",
+//       },
+//     });
+
+//     this._instance.interceptors.request.use((value) => {
+//       return value;
+//     });
+
+//     this._instance.interceptors.request.use((value) => {
+//       return value;
+//     });
+//   }
+
+//   get instance() {
+//     return this._instance;
+//   }
+// }

--- a/src/apis/major.ts
+++ b/src/apis/major.ts
@@ -1,0 +1,64 @@
+/*
+ * Created on Mon Dec 04 2023
+ *
+ * Copyright (c) 2023 Your Company
+ */
+
+import instance from "./instance";
+
+const apiPath = (path?: string) => {
+  return `/major${path ? `/${path}` : ""}`;
+};
+
+/**
+ * 전공 목록 전체 조회
+ */
+export const getMajorList = async () => {
+  const result =
+    await instance.get<Swagger.Api.GetAllMajors.ResponseBody>(apiPath());
+  return result.data;
+};
+
+/**
+ * 전공 코드 및 이름 생성
+ */
+export const createMajor = async (
+  args: Swagger.Api.CreateNewMajor.RequestBody
+) => {
+  const result = await instance.post<Swagger.Api.CreateNewMajor.ResponseBody>(
+    apiPath(),
+    args
+  );
+  return result.data;
+};
+
+// class MajorAPI extends BaseAPIInstance {
+//   constructor() {
+//     super();
+//   }
+
+//   private _apiPath = (path?: string) => {
+//     return `/major${path ? `/${path}` : ""}`;
+//   };
+
+//   /**
+//    * 전공 목록 전체 조회
+//    */
+//   getMajorList = async () => {
+//     const result = await this.instance.get<Swagger.Api.GetAllMajors.ResponseBody>(
+//       this._apiPath()
+//     );
+//     return result.data;
+//   };
+
+//   /**
+//    * 전공 코드 및 이름 생성
+//    */
+//   createMajor = async (args: Swagger.Api.CreateNewMajor.RequestBody) => {
+//     const result = await this.instance.post<Swagger.Api.CreateNewMajor.ResponseBody>(
+//       this._apiPath(),
+//       args
+//     );
+//     return result.data;
+//   };
+// }

--- a/src/apis/users.ts
+++ b/src/apis/users.ts
@@ -1,0 +1,35 @@
+/*
+ * Created on Mon Dec 04 2023
+ *
+ * Copyright (c) 2023 Your Company
+ */
+
+import instance from "./instance";
+
+const apiPath = (path?: string) => `/users${path ? `/${path}` : ""}`;
+
+/**
+ * 유저 생성(회원가입)
+ */
+export const signUp = async (args: Swagger.Api.AuthSignIn.RequestBody) => {
+  const result = await instance.post<Swagger.Api.AuthSignIn.ResponseBody>(
+    apiPath(),
+    args
+  );
+  return result.data;
+};
+
+// class UserAPI extends BaseAPIInstance {
+//   constructor() {
+//     super();
+//   }
+//   private _apiPath = (path?: string) => `/users${path ? `/${path}` : ""}`;
+
+//   signUp = async (args: Swagger.Api.AuthSignIn.RequestBody) => {
+//     const result = await this.instance.post<Swagger.Api.AuthSignIn.ResponseBody>(
+//       this._apiPath(),
+//       args
+//     );
+//     return result.data;
+//   };
+// }


### PR DESCRIPTION
# Pull Request

## 티켓

[QYOG-22](https://dongurami.atlassian.net/browse/QYOG-22)

## 작업 내용

- api 추가사항 적용
- class 형 api 선언방식 추가 후 주석 처리
- 싱글톤 class로 구성하는것과 클로저로 구성하는 것 중 어느것이 더 나을지 얘기해본 후
결정나는 사항으로 적용할 예정입니다.

## 스크린샷 

## 테스트 

## 기타
@pho9902 
signUp.ts는 제거 바랍니다. api 선언 파일은 백엔드에서 분리해놓은 도메인별로 만드는게 좋을거같아서요


[QYOG-22]: https://dongurami.atlassian.net/browse/QYOG-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ