### PR TITLE
feat(QYOG-89): 게시판 조회 방식 수정

### DIFF
--- a/src/components/UI/Header/Header.tsx
+++ b/src/components/UI/Header/Header.tsx
@@ -90,7 +90,9 @@ export default function Header({}: {}) {
             id="free-board"
             onClick={handleRoute}
             typoSize="Head5"
-            typoColor="neutral_60"
+            typoColor={
+              router.pathname === "/board/free" ? "neutral_90" : "neutral_60"
+            }
             hoverTypoColor="neutral_90"
           >
             수다 게시판
@@ -99,7 +101,9 @@ export default function Header({}: {}) {
             onClick={handleRoute}
             id="notice-board"
             typoSize="Head5"
-            typoColor="neutral_60"
+            typoColor={
+              router.pathname === "/board/notice" ? "neutral_90" : "neutral_60"
+            }
             hoverTypoColor="neutral_90"
           >
             공지 게시판

--- a/src/components/UI/Header/Header.tsx
+++ b/src/components/UI/Header/Header.tsx
@@ -49,7 +49,7 @@ export default function Header({}: {}) {
       }
 
       case "club": {
-        router.push("club/1?tab=home");
+        router.push("/club/1?tab=home");
         break;
       }
 
@@ -72,7 +72,11 @@ export default function Header({}: {}) {
             id="club"
             onClick={handleRoute}
             typoSize="Head5"
-            typoColor="neutral_60"
+            typoColor={
+              router.pathname === "/club/[clubID]"
+                ? "neutral_100"
+                : "neutral_60"
+            }
             hoverTypoColor="neutral_90"
           >
             동아리 둘러보기
@@ -91,7 +95,7 @@ export default function Header({}: {}) {
             onClick={handleRoute}
             typoSize="Head5"
             typoColor={
-              router.pathname === "/board/free" ? "neutral_90" : "neutral_60"
+              router.pathname === "/board/free" ? "neutral_100" : "neutral_60"
             }
             hoverTypoColor="neutral_90"
           >
@@ -102,7 +106,7 @@ export default function Header({}: {}) {
             id="notice-board"
             typoSize="Head5"
             typoColor={
-              router.pathname === "/board/notice" ? "neutral_90" : "neutral_60"
+              router.pathname === "/board/notice" ? "neutral_100" : "neutral_60"
             }
             hoverTypoColor="neutral_90"
           >

--- a/src/components/UI/Loader/Loader.tsx
+++ b/src/components/UI/Loader/Loader.tsx
@@ -1,0 +1,55 @@
+/*
+ * Created on Sun Feb 18 2024
+ *
+ * Copyright (c) 2024 Your Company
+ */
+
+import styled from "@emotion/styled";
+
+const Loader = styled.div`
+  width: 5rem;
+  height: 5rem;
+  border-radius: 50%;
+  position: relative;
+  background: ${({ theme }) => theme.color.primary_100}80;
+
+  &:before,
+  &:after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 5rem;
+    height: 5rem;
+    border-radius: 50%;
+    background: ${({ theme }) => theme.color.primary_100};
+    animation: slide 1s infinite linear alternate;
+    opacity: 0.5;
+  }
+  &:after {
+    animation: slide2 1s infinite linear alternate;
+    opacity: 1;
+  }
+  @keyframes slide {
+    0%,
+    20% {
+      transform: translate(0, 0);
+    }
+    80%,
+    100% {
+      transform: translate(20px, 20px);
+    }
+  }
+  @keyframes slide2 {
+    0%,
+    20% {
+      transform: translate(0, 0);
+    }
+    80%,
+    100% {
+      transform: translate(-20px, -20px);
+    }
+  }
+`;
+
+export default Loader;

--- a/src/components/UI/Loader/index.ts
+++ b/src/components/UI/Loader/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Created on Sun Feb 18 2024
+ *
+ * Copyright (c) 2024 Your Company
+ */
+
+export { default as Loader } from "./Loader";

--- a/src/components/UI/index.ts
+++ b/src/components/UI/index.ts
@@ -11,3 +11,4 @@ export * from "./Modal";
 export * from "./TextField";
 export * from "./Footer";
 export * from "./Header";
+export * from "./Loader";

--- a/src/pages/board/free/index.tsx
+++ b/src/pages/board/free/index.tsx
@@ -7,6 +7,7 @@
 import { GetStaticProps } from "next";
 import { useRouter } from "next/router";
 import { useQuery } from "@tanstack/react-query";
+import Head from "next/head";
 
 import { Column, Loader, Pagination, Typography, WhatIF } from "@/components";
 import { freePostsAPI } from "@/apis";
@@ -41,44 +42,49 @@ export default function FreeBoard(props: { boardName: string }) {
 
   if (isError) throw new Error("게시판을 불러올 수 없습니다.");
   return (
-    <Column horizonAlign="center" gap={10}>
-      <Column
-        horizonAlign="left"
-        style={{
-          width: "calc(100% - 512px)",
-          minWidth: 1408,
-          marginBottom: 20,
-        }}
-      >
-        <Typography typoSize="Head4" typoColor="primary_100">
-          {props.boardName}
-        </Typography>
-      </Column>
-      <WhatIF condition={!isLoading} falsy={<Loader />}>
-        {data && (
-          <Table
-            data={data}
-            type="free"
-            handleClickPostDetail={handleClickPostDetail}
-          />
-        )}
-
-        <SearchWriter />
-
-        <Pagination
-          defaultPage={data?.currentPage}
-          count={data?.lastPage || 1}
-          onChange={(_, page) => {
-            router.push({
-              pathname: "/board/free",
-              query: {
-                page,
-              },
-            });
+    <>
+      <Head>
+        <title>동그라미 - 수다 게시판</title>
+      </Head>
+      <Column horizonAlign="center" gap={10}>
+        <Column
+          horizonAlign="left"
+          style={{
+            width: "calc(100% - 512px)",
+            minWidth: 1408,
+            marginBottom: 20,
           }}
-        />
-      </WhatIF>
-    </Column>
+        >
+          <Typography typoSize="Head4" typoColor="primary_100">
+            {props.boardName}
+          </Typography>
+        </Column>
+        <WhatIF condition={!isLoading} falsy={<Loader />}>
+          {data && (
+            <Table
+              data={data}
+              type="free"
+              handleClickPostDetail={handleClickPostDetail}
+            />
+          )}
+
+          <SearchWriter />
+
+          <Pagination
+            defaultPage={data?.currentPage}
+            count={data?.lastPage || 1}
+            onChange={(_, page) => {
+              router.push({
+                pathname: "/board/free",
+                query: {
+                  page,
+                },
+              });
+            }}
+          />
+        </WhatIF>
+      </Column>
+    </>
   );
 }
 

--- a/src/pages/board/notice/index.tsx
+++ b/src/pages/board/notice/index.tsx
@@ -7,6 +7,7 @@
 import { GetStaticProps } from "next";
 import { useRouter } from "next/router";
 import { useQuery } from "@tanstack/react-query";
+import Head from "next/head";
 
 import { Column, Loader, Pagination, Typography, WhatIF } from "@/components";
 import { noticePostsAPI } from "@/apis";
@@ -41,43 +42,48 @@ export default function NoticeBoard(props: { boardName: string }) {
 
   if (isError) throw new Error("게시판을 불러올 수 없습니다.");
   return (
-    <Column horizonAlign="center" gap={10}>
-      <Column
-        horizonAlign="left"
-        style={{
-          width: "calc(100% - 512px)",
-          marginBottom: 20,
-        }}
-      >
-        <Typography typoSize="Head4" typoColor="primary_100">
-          {props.boardName}
-        </Typography>
-      </Column>
-      <WhatIF condition={!isLoading} falsy={<Loader />}>
-        {data && (
-          <Table
-            data={data}
-            type="free"
-            handleClickPostDetail={handleClickPostDetail}
-          />
-        )}
-
-        <SearchWriter />
-
-        <Pagination
-          defaultPage={data?.currentPage}
-          count={data?.lastPage || 1}
-          onChange={(_, page) => {
-            router.push({
-              pathname: "/board/notice",
-              query: {
-                page,
-              },
-            });
+    <>
+      <Head>
+        <title>동그라미 - 공지 게시판</title>
+      </Head>
+      <Column horizonAlign="center" gap={10}>
+        <Column
+          horizonAlign="left"
+          style={{
+            width: "calc(100% - 512px)",
+            marginBottom: 20,
           }}
-        />
-      </WhatIF>
-    </Column>
+        >
+          <Typography typoSize="Head4" typoColor="primary_100">
+            {props.boardName}
+          </Typography>
+        </Column>
+        <WhatIF condition={!isLoading} falsy={<Loader />}>
+          {data && (
+            <Table
+              data={data}
+              type="free"
+              handleClickPostDetail={handleClickPostDetail}
+            />
+          )}
+
+          <SearchWriter />
+
+          <Pagination
+            defaultPage={data?.currentPage}
+            count={data?.lastPage || 1}
+            onChange={(_, page) => {
+              router.push({
+                pathname: "/board/notice",
+                query: {
+                  page,
+                },
+              });
+            }}
+          />
+        </WhatIF>
+      </Column>
+    </>
   );
 }
 

--- a/src/pages/club/[clubID].tsx
+++ b/src/pages/club/[clubID].tsx
@@ -55,7 +55,7 @@ export default function ClubPage() {
   return (
     <div>
       <Head>
-        <title>동그라미 - {clubID} 동아리</title>
+        <title>동그라미 - 모던 애자일</title>
       </Head>
       <Row.ul gap={8}>
         {Object.entries(CLUB_TABS).map(([tabKey, tabValue]) => (


### PR DESCRIPTION
# Pull Request

## 티켓

[QYOG-89](https://dongurami.atlassian.net/browse/QYOG-89)

## 작업 내용

- getServersideProps 함수에서 api 호출하던 방식 제거
- getStaticProps로 게시판 이름 반환 (SEO에서 게시판 이름만 있으면 될 것 같아서 그렇게 했습니다)
- page 컴포넌트 내에서 useQuery 사용하여 api 호출


[QYOG-89]: https://dongurami.atlassian.net/browse/QYOG-89?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ